### PR TITLE
I had a large svg that I wanted to use as my watermark, this ran afoul of URL

### DIFF
--- a/source/partials/_javascripts.html.erb
+++ b/source/partials/_javascripts.html.erb
@@ -182,6 +182,10 @@ MEME.SVG = ( function ( $ ) {
   var addWatermark = function () {
     // Create a new image
     var img = new Image();
+
+    // Hat Tip: http://stackoverflow.com/questions/22710627/tainted-canvases-may-not-be-exported
+    img.crossOrigin = "anonymous";
+
     // Place the image
     img.onload = function() {
       context.globalAlpha = 0.8;


### PR DESCRIPTION
lengths. I figured out how to load the watermark over the wire, and not
trigger warning about a tainted canvas.

ala
http://stackoverflow.com/questions/22710627/tainted-canvases-may-not-be-exported
