### PR TITLE
Without 'bundle update' it fails on json 1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Meme is a generator that Vox Media uses to create social sharing images. See wor
 ## Install
 
 * `git clone https://github.com/voxmedia/meme.git`
+* `bundle update`
 * `bundle install`
 * `bundle exec middleman`
 


### PR DESCRIPTION
`bundle update` is a safe command to add before `bundle install`. Without it, it can fail with outdated versions as it fails on json 1.8.1 installation.